### PR TITLE
Fix NaN scores by using float32 embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ the `Qwen3-Embedding` model.
    `queries.txt` containing matching queries.
 2. Place the code snippet you want to compare in a file and run:
 
-   ```bash
-   python test_code_embedding.py --document path/to/code.py
-   ```
+    ```bash
+    python test_code_embedding.py --document path/to/code.py
+    ```
+
+    The script casts the model to `float32` automatically when running on
+    CPU to avoid NaN values in the computed embeddings.
 
 The script will read the task descriptions from `task_prompts.json`,
 compose prompts from the tasks and queries and print the cosine

--- a/test_code_embedding.py
+++ b/test_code_embedding.py
@@ -67,6 +67,7 @@ def embed_texts(texts, model_name: str, max_length: int = 8192) -> torch.Tensor:
         model_name, padding_side="left", trust_remote_code=True
     )
     model = AutoModel.from_pretrained(model_name, trust_remote_code=True)
+    model.to(torch.float32)
     model.eval()
 
     batch = tokenizer(
@@ -79,7 +80,7 @@ def embed_texts(texts, model_name: str, max_length: int = 8192) -> torch.Tensor:
     batch.to(model.device)
     with torch.no_grad():
         outputs = model(**batch)
-    embeddings = last_token_pool(outputs.last_hidden_state, batch["attention_mask"])
+    embeddings = last_token_pool(outputs.last_hidden_state.float(), batch["attention_mask"])
     return F.normalize(embeddings, p=2, dim=1)
 
 


### PR DESCRIPTION
## Summary
- cast the Qwen3 model to float32 to avoid NaN scores
- update README with CPU casting note

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68773d5e3c4883328ba70bf5aa8e32af